### PR TITLE
Load version on import

### DIFF
--- a/djapipes/__init__.py
+++ b/djapipes/__init__.py
@@ -1,0 +1,3 @@
+from .version import __version__
+
+from . import run


### PR DESCRIPTION
Import version string so the following works:

```python
>>> import djapipes
>>> print(djapipes.__version__)
'0.1.dev60+ge8417ee.d20241216'
```