### PR TITLE
Add publish action

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,43 @@
+name: Publish-to-pypi
+
+on:
+  release:
+    types: [released]
+  # push:
+  #   branches:
+  #     - master
+  # pull_request:
+  workflow_dispatch:
+
+jobs:
+  build_sdist:
+    name: source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Build sdist
+        run: |
+          pip install build
+          python -m build --sdist
+      - uses: actions/upload-artifact@v4
+        with:
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    name: upload to PyPI
+    needs: [build_sdist]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' &&
+        github.event.ref_type == 'tag' &&
+        github.ref == 'refs/heads/${{ github.event.repository.default_branch }}'
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: artifact
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -39,5 +39,3 @@ jobs:
           name: artifact
           path: dist
       - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Add `.github/workflows/publish-to-pypi.yml` to publish tagged versions to pypi.org.