### PR TITLE
remove git dependencies and add install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # dja-pipes
 Runs BAGPIPES on any JWST/NIRSpec PRISM spectrum from the DAWN JWST Archive (DJA)
 
+Installation
+============
+
+```bash
+pip install djapipes git+https://github.com/RashmiGot/bagpipes.git#egg=bagpipes git+https://github.com/karllark/dust_attenuation.git 
+```
+
 See also
 --------
 DJA: https://dawn-cph.github.io/dja/ <br>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-git+https://github.com/RashmiGot/bagpipes.git#egg=bagpipes
-jupyter
-git+https://github.com/astropy/photutils.git@1.12.0
+# git+https://github.com/RashmiGot/bagpipes.git#egg=bagpipes
+photutils==1.12.0
 grizli[aws]
 eazy
-git+https://github.com/karllark/dust_attenuation.git
+# git+https://github.com/karllark/dust_attenuation.git
 msaexp
 wget
 tabulate


### PR DESCRIPTION
Can't have `git` dependencies in `requirements.txt` on pypi.  Remove them and add the dependency installation instructions to the main README.