### PR TITLE
Dependencies are in setup.cfg

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-# git+https://github.com/RashmiGot/bagpipes.git#egg=bagpipes
-photutils==1.12.0
-grizli[aws]
-eazy
-# git+https://github.com/karllark/dust_attenuation.git
-msaexp
-wget
-tabulate

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,11 +25,9 @@ python_requires = >=3.10
 packages = 
     djapipes
 install_requires = 
-    bagpipes
-    jupyter
     grizli[aws]
+    photutils==1.12.0
     eazy
-    dust_attenuation @ git+https://github.com/karllark/dust_attenuation.git
     msaexp
     wget
     tabulate


### PR DESCRIPTION
Remove `requirements.txt` because `pip` dependencies are listed in `setup.cfg`.